### PR TITLE
Import `tmc2209_hub` for custom ESPHome component examples

### DIFF
--- a/Software/ESPHome/PD-Stepper-Blinds-Advanced.yaml
+++ b/Software/ESPHome/PD-Stepper-Blinds-Advanced.yaml
@@ -3,7 +3,7 @@
 
 external_components:
   - source: github://slimcdk/esphome-custom-components
-    components: [tmc2209, stepper]
+    components: [tmc2209_hub, tmc2209, stepper]
 
 substitutions:
   encoder_closed_pos: "30000" # full blinds length (in encoder counts) !! CHANGE TO SUIT YOUR SETUP !!

--- a/Software/ESPHome/PD-Stepper-Position-Control.yaml
+++ b/Software/ESPHome/PD-Stepper-Position-Control.yaml
@@ -3,7 +3,7 @@
 
 external_components:
   - source: github://slimcdk/esphome-custom-components
-    components: [tmc2209, stepper]
+    components: [tmc2209_hub, tmc2209, stepper]
 
 globals:
   - id: encoder_tracking_


### PR DESCRIPTION
A fix for multiple drivers on same UART has been implement which now requires [`tmc2209_hub`](https://github.com/slimcdk/esphome-custom-components/blob/1fe4aaa56b7ed8a6b7a68addfba7b9bfa986b6fa/esphome/components/tmc2209/README.md#configuration-of-hub)  to be imported as well. It will auto configure, so no additional configuration is required.